### PR TITLE
Added Redirector interface to let you generically support redirects.

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,13 +1,15 @@
+#
+# Runs the test suite for the module.
+#
 test:
 	@ \
-	go test ./...
+	go test -timeout 5s ./...
 
+#
+# Runs the test suite for the whole module, spitting out the the code coverage report to find gaps.
+#
 coverage:
 	@ \
-	go test -cover -timeout 5s ./...
-
-coverage-report:
-	@ \
-	go test -coverprofile=coverage.out && \
+	go test -coverprofile=coverage.out -timeout 5s ./... && \
 	go tool cover -func=coverage.out && \
 	rm coverage.out

--- a/respond.go
+++ b/respond.go
@@ -186,14 +186,50 @@ func (r Responder) DownloadBytes(fileName string, data []byte, errs ...error) {
 
 // Redirect performs a 307-style TEMPORARY redirect to the given resource. You can use printf-style
 // formatting to make it easier to build the location you're redirecting to.
-func (r Responder) Redirect(uri string, args ...interface{}) {
-	http.Redirect(r.writer, r.request, fmt.Sprintf(uri, args...), http.StatusTemporaryRedirect)
+func (r Responder) Redirect(uriFormat string, args ...interface{}) {
+	uri := fmt.Sprintf(uriFormat, args...)
+	if uri == "" {
+		r.Fail(fmt.Errorf("unable to redirect to empty url"))
+		return
+	}
+	http.Redirect(r.writer, r.request, uri, http.StatusTemporaryRedirect)
+}
+
+// RedirectTo performs a 307-style TEMPORARY redirect to the URL returned by calling Redirect() on your value.
+func (r Responder) RedirectTo(redirector Redirector, errs ...error) {
+	if err := firstError(errs...); err != nil {
+		r.Fail(err)
+		return
+	}
+	if redirector == nil {
+		r.Fail(fmt.Errorf("unable to redirect using nil redirector"))
+		return
+	}
+	r.Redirect(redirector.Redirect())
 }
 
 // RedirectPermanent performs a 308-style PERMANENT redirect to the given resource. You can use printf-style
 // formatting to make it easier to build the location you're redirecting to.
-func (r Responder) RedirectPermanent(uri string, args ...interface{}) {
-	http.Redirect(r.writer, r.request, fmt.Sprintf(uri, args...), http.StatusPermanentRedirect)
+func (r Responder) RedirectPermanent(uriFormat string, args ...interface{}) {
+	uri := fmt.Sprintf(uriFormat, args...)
+	if uri == "" {
+		r.Fail(fmt.Errorf("unable to redirect to empty url"))
+		return
+	}
+	http.Redirect(r.writer, r.request, uri, http.StatusPermanentRedirect)
+}
+
+// RedirectPermanentTo performs a 308-style PERMANENT redirect to the URL returned by calling Redirect() on your value.
+func (r Responder) RedirectPermanentTo(redirector Redirector, errs ...error) {
+	if err := firstError(errs...); err != nil {
+		r.Fail(err)
+		return
+	}
+	if redirector == nil {
+		r.Fail(fmt.Errorf("unable to redirect using nil redirector"))
+		return
+	}
+	r.RedirectPermanent(redirector.Redirect())
 }
 
 // NotModified writes a 304 response with no content. You typically will use this when performing

--- a/respond_test.go
+++ b/respond_test.go
@@ -267,6 +267,24 @@ func (suite RespondSuite) TestHTMLTemplate_evalError() {
 	suite.assertStatus(w, 500)
 }
 
+func (suite RespondSuite) TestRedirect_empty() {
+	w := newResponseWriter()
+	req := newRequest()
+
+	// We don't really care about what the error "says" as long as it fails w/ a 500
+	respond.To(w, req).Redirect("")
+	suite.assertStatus(w, 500)
+}
+
+func (suite RespondSuite) TestRedirect_emptyAfterSubstitution() {
+	w := newResponseWriter()
+	req := newRequest()
+
+	// We don't really care about what the error "says" as long as it fails w/ a 500
+	respond.To(w, req).Redirect("%s%s", "", "")
+	suite.assertStatus(w, 500)
+}
+
 func (suite RespondSuite) TestRedirect_exact() {
 	w := newResponseWriter()
 	req := newRequest()
@@ -287,6 +305,65 @@ func (suite RespondSuite) TestRedirect_substitutions() {
 	suite.assertHeader(w, "Location", "https://google.com?q=hello")
 }
 
+func (suite RespondSuite) TestRedirectTo_nil() {
+	w := newResponseWriter()
+	req := newRequest()
+
+	// We don't really care about what the error "says" as long as it fails w/ a 500
+	respond.To(w, req).RedirectTo(nil)
+	suite.assertStatus(w, 500)
+}
+
+func (suite RespondSuite) TestRedirectTo_valid() {
+	w := newResponseWriter()
+	req := newRequest()
+
+	respond.To(w, req).RedirectTo(fakeRedirector{URL: "https://google.com/foo"})
+	suite.assertStatus(w, 307)
+	suite.assertHeader(w, "Location", "https://google.com/foo")
+}
+
+func (suite RespondSuite) TestRedirectTo_error() {
+	w := newResponseWriter()
+	req := newRequest()
+
+	respond.To(w, req).RedirectTo(fakeRedirector{URL: "https://google.com/foo"}, errorWithStatus{
+		status:  403,
+		message: "nope",
+	})
+	suite.assertError(w, 403, "nope")
+}
+
+// Should ignore the fact that the Redirector is nil when there's an error present.
+func (suite RespondSuite) TestRedirectTo_errorNilInput() {
+	w := newResponseWriter()
+	req := newRequest()
+
+	respond.To(w, req).RedirectTo(nil, errorWithStatus{
+		status:  403,
+		message: "nope",
+	})
+	suite.assertError(w, 403, "nope")
+}
+
+func (suite RespondSuite) TestRedirectPermanent_empty() {
+	w := newResponseWriter()
+	req := newRequest()
+
+	// We don't really care about what the error "says" as long as it fails w/ a 500
+	respond.To(w, req).RedirectPermanent("")
+	suite.assertStatus(w, 500)
+}
+
+func (suite RespondSuite) TestRedirectPermanent_emptyAfterSubstitution() {
+	w := newResponseWriter()
+	req := newRequest()
+
+	// We don't really care about what the error "says" as long as it fails w/ a 500
+	respond.To(w, req).RedirectPermanent("%s%s", "", "")
+	suite.assertStatus(w, 500)
+}
+
 func (suite RespondSuite) TestRedirectPermanent_exact() {
 	w := newResponseWriter()
 	req := newRequest()
@@ -305,6 +382,47 @@ func (suite RespondSuite) TestRedirectPermanent_substitutions() {
 	suite.assertStatus(w, 308)
 	suite.assertHeader(w, "Content-Type", "")
 	suite.assertHeader(w, "Location", "https://google.com?q=hello")
+}
+
+func (suite RespondSuite) TestRedirectPermanentTo_nil() {
+	w := newResponseWriter()
+	req := newRequest()
+
+	// We don't really care about what the error "says" as long as it fails w/ a 500
+	respond.To(w, req).RedirectPermanentTo(nil)
+	suite.assertStatus(w, 500)
+}
+
+func (suite RespondSuite) TestRedirectPermanentTo_valid() {
+	w := newResponseWriter()
+	req := newRequest()
+
+	respond.To(w, req).RedirectPermanentTo(fakeRedirector{URL: "https://google.com/foo"})
+	suite.assertStatus(w, 308)
+	suite.assertHeader(w, "Location", "https://google.com/foo")
+}
+
+func (suite RespondSuite) TestRedirectPermanentTo_error() {
+	w := newResponseWriter()
+	req := newRequest()
+
+	respond.To(w, req).RedirectPermanentTo(fakeRedirector{URL: "https://google.com/foo"}, errorWithStatus{
+		status:  403,
+		message: "nope",
+	})
+	suite.assertError(w, 403, "nope")
+}
+
+// Should ignore the fact that the Redirector is nil when there's an error present.
+func (suite RespondSuite) TestRedirectPermanentTo_errorNilInput() {
+	w := newResponseWriter()
+	req := newRequest()
+
+	respond.To(w, req).RedirectPermanentTo(nil, errorWithStatus{
+		status:  403,
+		message: "nope",
+	})
+	suite.assertError(w, 403, "nope")
 }
 
 func (suite RespondSuite) TestFail_unknownCode() {


### PR DESCRIPTION
In addition to calling `responder.Redirect(...)` directly, you can now supply a `Redirector` value to any success call or `Reply()` and instead of JSON-marshaling the struct, it will extract the URL and redirect to it:

```go
type S3FileRedirect struct {
    Bucket string
    Key    string
}

func (f S3FileRedirect) Redirect() string {
    return fmt.Sprintf("https://%s.s3.amazonaws.com/%s/%s",
        f.Bucket,
        f.Directory,
        f.Name,
}

...
response.RedirectTo(someFile)
```