### PR TITLE
Can handle raw files by implementing io.Reader.

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,93 @@ In addition to writing the bytes, `respond` will apply the correct
 `Content-Type` and `Content-Disposition` headers based on the name/extension
 of the file you provide.
 
+### Raw Files By Implementing io.Reader
+
+If you'd like to decouple yourself further from the `respond`
+library when serving up raw files, you can continue to respond
+using `Ok()` with your own structs/values as long as it implements
+`io.Reader`. When `respond` comes across a result that also
+implements the reader interface, it will assume that you want
+to return that reader's raw bytes rather than marshaling the
+struct as JSON:
+
+```go
+func ExportCSV(w http.ResponseWriter, req *http.Request) {
+    // This is an *Export which implements io.Reader
+    export := crunchTheNumbers() 
+
+    // Respond with the raw CSV reader data and the following:
+    // Status = 200
+    // Content-Type = 'application/octet-stream'
+    // Content-Disposition = 'inline'
+    // Body = (whatever .Read() gave us)
+    respond.To(w, req).Ok(export)
+}
+
+type Export struct {
+    RawData *bytes.Buffer
+}
+
+func (e Export) Read(b []byte) (int, error) {
+    return e.RawData.Read(b)
+}
+```
+
+Most of the time you probably don't want that generic
+content type. In other instances you may want to trigger a download, instead. To
+rectify that, you can implement two optional interfaces to
+customize both behaviors:
+
+```go
+// Implement this to customize the "Content-Type" header.
+type ContentTypeSpecified interface {
+    ContentType() string
+}
+
+// Implement this to allow an "attachment" disposition instead.
+// The value you return will be the default file name offered to
+// the client/user when downloading.
+type FileNameSpecified interface {
+    FileName() string
+}
+```
+
+Updating our example to customize both values, we end up
+with the following:
+
+```go
+func ExportCSV(w http.ResponseWriter, req *http.Request) {
+    // This is an *Export which implements io.Reader,
+    // ContentTypeSpecifier, and FileNameSpecifier.
+    export := crunchTheNumbers()
+
+    // Respond with the raw CSV reader data and the following:
+    // Status = 200
+    // Content-Type = 'text/csv'
+    // Content-Disposition = 'attachment; filename="super-important-report.csv"'
+    // Body = (whatever .Read() gave us)
+    respond.To(w, req).Ok(export)
+}
+
+// ---
+
+type Export struct {
+    RawData *bytes.Buffer
+}
+
+func (e Export) Read(b []byte) (int, error) {
+    return e.RawData.Read(b)
+}
+
+func (e Export) ContentType() string {
+    return "text/csv" 
+}
+
+func (e Export) FileName() string {
+    return "super-important-report.csv"
+}
+```
+
 ### Responding With HTML
 
 While most of `respond` was built to support building REST APIs,


### PR DESCRIPTION
Mostly an update to make Frodo a bit more robust, you can now serve up raw files/content as long as your result value implements `io.Reader`. This way you don't have to explicitly call `Serve()` or `Download()`.

You can customize the header behavior by implementing some optional interfaces as well.